### PR TITLE
feat: add device information service getter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "uplift-ble"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
   { name = "Eric McDonald", email = "106356608+librick@users.noreply.github.com" },
 ]

--- a/scripts/param_type_height.py
+++ b/scripts/param_type_height.py
@@ -1,0 +1,46 @@
+import re
+import click
+
+from uplift_ble.units import convert_cm_to_mm, convert_in_to_mm, round_half_up
+
+UNIT_RE = re.compile(r"^(\d+(?:\.\d+)?)(mm|cm|in)$", re.IGNORECASE)
+
+
+class HeightParam(click.ParamType):
+    name = "height"
+
+    def convert(self, value, param, ctx):
+        m = UNIT_RE.fullmatch(value)
+        if not m:
+            if re.fullmatch(r"^\d+(?:\.\d+)?$", value):
+                self.fail(
+                    f"{value!r} is missing a unit suffix; expected one of 'mm', 'cm', or 'in'.",
+                    param,
+                    ctx,
+                )
+            self.fail(
+                f"{value!r} is not a valid height (expected e.g. '64cm', '26.5in', or '660mm')",
+                param,
+                ctx,
+            )
+
+        num_str, unit = m.groups()
+        val = float(num_str)
+        u = unit.lower()
+
+        if u == "mm":
+            mm_val = val
+        elif u == "cm":
+            mm_val = convert_cm_to_mm(val)
+        elif u == "in":
+            mm_val = convert_in_to_mm(val)
+        else:
+            # This should never happen if the regex is correct.
+            raise AssertionError(
+                f"Internal error: unexpected unit {u!r}. Please report this as a bug."
+            )
+
+        return int(round_half_up(mm_val))
+
+
+HEIGHT = HeightParam()

--- a/scripts/param_type_mac_address.py
+++ b/scripts/param_type_mac_address.py
@@ -1,7 +1,7 @@
 import re
 import click
 
-MAC_PATTERN = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
+MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
 
 
 class MACAddress(click.ParamType):
@@ -10,7 +10,7 @@ class MACAddress(click.ParamType):
     def convert(self, value, param, ctx):
         if value is None:
             return None
-        if MAC_PATTERN.match(value):
+        if MAC_RE.match(value):
             return value.lower()
         self.fail(f"{value!r} is not a valid MAC address", param, ctx)
 

--- a/scripts/param_types.py
+++ b/scripts/param_types.py
@@ -1,0 +1,18 @@
+import re
+import click
+
+MAC_PATTERN = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
+
+
+class MACAddress(click.ParamType):
+    name = "mac_address"
+
+    def convert(self, value, param, ctx):
+        if value is None:
+            return None
+        if MAC_PATTERN.match(value):
+            return value.lower()
+        self.fail(f"{value!r} is not a valid MAC address", param, ctx)
+
+
+MAC_ADDRESS = MACAddress()

--- a/scripts/uplift_ble_cli.py
+++ b/scripts/uplift_ble_cli.py
@@ -10,6 +10,7 @@ import logging
 import typer
 from typing import Optional
 
+from param_types import MAC_ADDRESS
 from uplift_ble import units
 from uplift_ble.desk import Desk
 from uplift_ble.scanner import DeskScanner
@@ -89,7 +90,11 @@ def discover(timeout: float = typer.Option(5.0, help="Discovery duration in seco
 @app.command()
 def listen(
     address: Optional[str] = typer.Option(
-        None, "-a", "--address", help="Bluetooth address of the desk"
+        None,
+        "-a",
+        "--address",
+        click_type=MAC_ADDRESS,
+        help="Bluetooth address of the desk",
     ),
     timeout: float = typer.Option(
         5.0, "-t", "--timeout", help="Scan timeout if address omitted"
@@ -148,7 +153,11 @@ def get_current_height(ctx: typer.Context):
 def common_options(
     ctx: typer.Context,
     address: Optional[str] = typer.Option(
-        None, "-a", "--address", help="Bluetooth address of the desk"
+        None,
+        "-a",
+        "--address",
+        click_type=MAC_ADDRESS,
+        help="Bluetooth address of the desk",
     ),
     timeout: float = typer.Option(
         5.0, "-t", "--timeout", help="Timeout for discovery when address omitted"

--- a/scripts/uplift_ble_cli.py
+++ b/scripts/uplift_ble_cli.py
@@ -4,6 +4,7 @@ CLI to test the uplift_ble module.
 """
 
 import asyncio
+import json
 import logging
 
 import typer
@@ -109,6 +110,21 @@ def listen(
         asyncio.run(_listen())
     except KeyboardInterrupt:
         typer.echo("Stopped listening.")
+
+
+@app.command()
+def get_device_information(ctx: typer.Context):
+    """
+    Get standard BLE device information service (DIS) values.
+
+    This implementation is non-exhaustive. It only returns information
+    for a few well-known, standard characteristics.
+    If you think your device supports non-standard characteristics within the standard service,
+    consider using a different tool to dump the values of all readable characteristics.
+    """
+    address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
+    device_info = asyncio.run(Desk(address).get_device_information())
+    typer.echo(json.dumps(device_info, indent=4, ensure_ascii=False))
 
 
 @app.command()

--- a/scripts/uplift_ble_cli.py
+++ b/scripts/uplift_ble_cli.py
@@ -124,7 +124,8 @@ def get_device_information(ctx: typer.Context):
     consider using a different tool to dump the values of all readable characteristics.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    device_info = asyncio.run(Desk(address).get_device_information())
+    requires_wake = ctx.obj["requires_wake"]
+    device_info = asyncio.run(Desk(address, requires_wake).get_device_information())
     typer.echo(json.dumps(device_info, indent=4, ensure_ascii=False))
 
 
@@ -134,7 +135,8 @@ def get_current_height(ctx: typer.Context):
     Get the most recently-received desk height.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    height_mm = asyncio.run(Desk(address).get_current_height())
+    requires_wake = ctx.obj["requires_wake"]
+    height_mm = asyncio.run(Desk(address, requires_wake).get_current_height())
     if height_mm is None:
         typer.echo("Error: failed to retrieve current height")
         raise typer.Exit(code=1)
@@ -162,11 +164,21 @@ def common_options(
         click_type=click.FloatRange(min=0.0),
         help="Timeout for discovery when address omitted",
     ),
+    requiresWake: bool = typer.Option(
+        False,
+        "-w",
+        "--requires-wake",
+        help="If set, send wake commands prior to subsequent commands",
+    ),
 ):
     """
     Common options injected for commands requiring a desk address.
     """
-    ctx.obj = {"address": address, "timeout": timeout}
+    ctx.obj = {
+        "address": address,
+        "timeout": timeout,
+        "requires_wake": requiresWake,
+    }
 
 
 @app.command()
@@ -175,7 +187,8 @@ def move_up(ctx: typer.Context):
     Move the desk up.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).move_up())
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(Desk(address, requires_wake).move_up())
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 
@@ -185,7 +198,8 @@ def move_down(ctx: typer.Context):
     Move the desk down.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).move_down())
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(Desk(address, requires_wake).move_down())
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 
@@ -195,7 +209,8 @@ def request_height_limits(ctx: typer.Context):
     Request height limits from the desk.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).request_height_limits())
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(Desk(address, requires_wake).request_height_limits())
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 
@@ -209,7 +224,10 @@ def set_calibration_offset(
     Set the calibration offset.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).set_calibration_offset(calibration_offset))
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(
+        Desk(address, requires_wake).set_calibration_offset(calibration_offset)
+    )
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 
@@ -223,7 +241,8 @@ def set_height_limit_max(
     Set the maximum height limit.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).set_height_limit_max(max_height))
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(Desk(address, requires_wake).set_height_limit_max(max_height))
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 
@@ -238,7 +257,8 @@ def move_to_specified_height(
     Move the desk to a specified height.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).move_to_specified_height(height))
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(Desk(address, requires_wake).move_to_specified_height(height))
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 
@@ -248,7 +268,10 @@ def set_current_height_as_height_limit_max(ctx: typer.Context):
     Set current height as the maximum height limit.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).set_current_height_as_height_limit_max())
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(
+        Desk(address, requires_wake).set_current_height_as_height_limit_max()
+    )
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 
@@ -258,7 +281,10 @@ def set_current_height_as_height_limit_min(ctx: typer.Context):
     Set current height as the minimum height limit.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).set_current_height_as_height_limit_min())
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(
+        Desk(address, requires_wake).set_current_height_as_height_limit_min()
+    )
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 
@@ -268,7 +294,8 @@ def clear_height_limit_max(ctx: typer.Context):
     Clear the maximum height limit.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).clear_height_limit_max())
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(Desk(address, requires_wake).clear_height_limit_max())
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 
@@ -278,7 +305,8 @@ def clear_height_limit_min(ctx: typer.Context):
     Clear the minimum height limit.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).clear_height_limit_min())
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(Desk(address, requires_wake).clear_height_limit_min())
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 
@@ -288,7 +316,8 @@ def stop_movement(ctx: typer.Context):
     Stop desk movement.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).stop_movement())
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(Desk(address, requires_wake).stop_movement())
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 
@@ -301,7 +330,8 @@ def set_units_to_centimeters(
     Set units to centimeters.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).set_units_to_centimeters())
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(Desk(address, requires_wake).set_units_to_centimeters())
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 
@@ -314,7 +344,8 @@ def set_units_to_inches(
     Set units to inches.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).set_units_to_inches())
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(Desk(address, requires_wake).set_units_to_inches())
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 
@@ -324,7 +355,8 @@ def reset(ctx: typer.Context):
     Reset the desk.
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
-    packet = asyncio.run(Desk(address).reset())
+    requires_wake = ctx.obj["requires_wake"]
+    packet = asyncio.run(Desk(address, requires_wake).reset())
     typer.echo(f"Sent {ctx.info_name} packet to {address}: {packet.hex()}")
 
 

--- a/scripts/uplift_ble_cli.py
+++ b/scripts/uplift_ble_cli.py
@@ -89,21 +89,12 @@ def discover(timeout: float = typer.Option(5.0, help="Discovery duration in seco
 
 @app.command()
 def listen(
-    address: Optional[str] = typer.Option(
-        None,
-        "-a",
-        "--address",
-        click_type=MAC_ADDRESS,
-        help="Bluetooth address of the desk",
-    ),
-    timeout: float = typer.Option(
-        5.0, "-t", "--timeout", help="Scan timeout if address omitted"
-    ),
+    ctx: typer.Context,
 ):
     """
     Listen continuously for notifications from the desk and print parsed packets.
     """
-    addr = _resolve_address(address, timeout)
+    addr = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
     typer.echo(f"Listening for notifications on {addr} (Ctrl-C to stop)…")
 
     async def _listen():

--- a/src/uplift_ble/ble_characteristics.py
+++ b/src/uplift_ble/ble_characteristics.py
@@ -11,9 +11,16 @@ https://www.bluetooth.com/specifications/assigned-numbers/
 
 from bleak.uuids import normalize_uuid_16
 
+BLE_CHAR_UUID_DIS_MANUFACTURER_NAME = normalize_uuid_16(0x2A29)
+BLE_CHAR_UUID_DIS_MODEL_NUMBER = normalize_uuid_16(0x2A24)
+BLE_CHAR_UUID_DIS_SERIAL_NUMBER = normalize_uuid_16(0x2A25)
+BLE_CHAR_UUID_DIS_HARDWARE_REV = normalize_uuid_16(0x2A27)
+BLE_CHAR_UUID_DIS_FIRMWARE_REV = normalize_uuid_16(0x2A26)
+BLE_CHAR_UUID_DIS_SOFTWARE_REV = normalize_uuid_16(0x2A28)
+BLE_CHAR_UUID_DIS_SYSTEM_ID = normalize_uuid_16(0x2A23)
+BLE_CHAR_UUID_DIS_PNP_ID = normalize_uuid_16(0x2A50)
 
 # UUID for sending control commands to the Uplift BLE adapter.
 BLE_CHAR_UUID_UPLIFT_DESK_CONTROL: str = normalize_uuid_16(0xFE61)
-
 # UUID for receiving status and output values from the Uplift BLE adapter.
 BLE_CHAR_UUID_UPLIFT_DESK_OUTPUT: str = normalize_uuid_16(0xFE62)

--- a/src/uplift_ble/ble_services.py
+++ b/src/uplift_ble/ble_services.py
@@ -11,5 +11,7 @@ https://www.bluetooth.com/specifications/assigned-numbers/
 
 from bleak.uuids import normalize_uuid_16
 
+# UUID for the BLE Device Information Service (DIS).
+BLE_SERVICE_UUID_DEVICE_INFORMATION_SERVICE: str = normalize_uuid_16(0x180A)
 # UUID for a service which allows clients to discover nearby Uplift adapters.
 BLE_SERVICE_UUID_UPLIFT_DISCOVERY: str = normalize_uuid_16(0xFE60)

--- a/src/uplift_ble/desk.py
+++ b/src/uplift_ble/desk.py
@@ -30,7 +30,7 @@ from uplift_ble.packet import (
 )
 from uplift_ble.units import (
     convert_hundredths_of_mm_to_mm,
-    convert_mm_to_inches,
+    convert_mm_to_in,
 )
 
 logger = logging.getLogger(__name__)
@@ -226,7 +226,7 @@ class Desk:
         if p.opcode == 0x01:
             tenths = int.from_bytes(p.payload, byteorder="big", signed=False)
             mm = convert_hundredths_of_mm_to_mm(tenths)
-            inches = convert_mm_to_inches(mm)
+            inches = convert_mm_to_in(mm)
             logger.info(
                 f"- Received packet, opcode=0x{p.opcode:02X}, current height: {mm} mm (~{inches} in)"
             )
@@ -238,13 +238,13 @@ class Desk:
             )
         elif p.opcode == 0x10:
             mm = int.from_bytes(p.payload, byteorder="big", signed=False)
-            inches = convert_mm_to_inches(mm)
+            inches = convert_mm_to_in(mm)
             logger.info(
                 f"- Received packet, opcode=0x{p.opcode:02X}, calibration height: {mm} mm (~{inches} in)"
             )
         elif p.opcode == 0x11:
             mm = int.from_bytes(p.payload, byteorder="big", signed=False)
-            inches = convert_mm_to_inches(mm)
+            inches = convert_mm_to_in(mm)
             logger.info(
                 f"- Received packet, opcode=0x{p.opcode:02X}, height limit max: {mm} mm (~{inches} in)"
             )

--- a/src/uplift_ble/units.py
+++ b/src/uplift_ble/units.py
@@ -9,12 +9,12 @@ def convert_mm_to_inches(mm: int | float) -> float:
     return round_half_up(mm * 0.039, num_digits=1)
 
 
-def convert_tenths_of_mm_to_mm(tenths_of_mm: int | float) -> float:
+def convert_hundredths_of_mm_to_mm(hundredths_of_mm: int | float) -> float:
     """
-    Converts a value in tenths of a millimeter to millimeters, rounding using half-up to the nearest whole number.
+    Converts a value in hundredths of a millimeter to millimeters, rounding using half-up to the nearest whole number.
     """
-    # 1 tenth of a millimeter = 0.1 mm
-    return round_half_up(tenths_of_mm * 0.1)
+    # 1 hundredth of a millimeter = 0.01 mm
+    return round_half_up(hundredths_of_mm * 0.01)
 
 
 def round_half_up(value: int | float, num_digits=0):

--- a/src/uplift_ble/units.py
+++ b/src/uplift_ble/units.py
@@ -1,7 +1,7 @@
 from decimal import ROUND_HALF_UP, Decimal
 
 
-def convert_mm_to_inches(mm: int | float) -> float:
+def convert_mm_to_in(mm: int | float) -> float:
     """
     Converts a value in millimeters to an approximate value in inches, rounding using half-up to one decimal place.
     """
@@ -15,6 +15,21 @@ def convert_hundredths_of_mm_to_mm(hundredths_of_mm: int | float) -> float:
     """
     # 1 hundredth of a millimeter = 0.01 mm
     return round_half_up(hundredths_of_mm * 0.01)
+
+
+def convert_in_to_mm(inches: int | float) -> float:
+    """
+    Converts a value in inches to millimeters.
+    """
+    # 1 inch = 25.4 mm
+    return inches * 25.4
+
+
+def convert_cm_to_mm(cm: int | float) -> float:
+    """
+    Converts a value in centimeters to a value in millimeters.
+    """
+    return cm * 10
 
 
 def round_half_up(value: int | float, num_digits=0):

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,6 +1,6 @@
 import pytest
 from uplift_ble.units import (
-    convert_mm_to_inches,
+    convert_mm_to_in,
     convert_hundredths_of_mm_to_mm,
     round_half_up,
 )
@@ -15,8 +15,8 @@ from uplift_ble.units import (
         (762, 29.7),
     ],
 )
-def test_convert_mm_to_inches(input: float, expected: float):
-    actual = convert_mm_to_inches(input)
+def test_convert_mm_to_in(input: float, expected: float):
+    actual = convert_mm_to_in(input)
     assert actual == expected
 
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,7 +1,7 @@
 import pytest
 from uplift_ble.units import (
     convert_mm_to_inches,
-    convert_tenths_of_mm_to_mm,
+    convert_hundredths_of_mm_to_mm,
     round_half_up,
 )
 
@@ -22,10 +22,10 @@ def test_convert_mm_to_inches(input: float, expected: float):
 
 @pytest.mark.parametrize(
     "input,expected",
-    [(0, 0), (10, 1), (100, 10), (1000, 100), (4, 0), (5, 1), (6, 1)],
+    [(0, 0), (100, 1), (1000, 10), (10000, 100), (40, 0), (50, 1), (60, 1)],
 )
-def test_convert_tenths_of_mm_to_mm(input: float, expected: float):
-    actual = convert_tenths_of_mm_to_mm(input)
+def test_convert_hundredths_of_mm_to_mm(input: float, expected: float):
+    actual = convert_hundredths_of_mm_to_mm(input)
     assert actual == expected
 
 


### PR DESCRIPTION
This PR does the following:

Bugfixes:
- Replaces the `listen` command's `--address` and `--timeout` local options with global options
- Fixes the off-by-10 error in the get-current-height command

Features:
- Adds a new desk method for returning info from the standard BLE device information service
- Adds input validation for global options `--address` and `--timeout`
- Adds new `--requires-wake` global option to send wake commands before other commands
- Changes move-to-specified height to support dynamic units. E.g., specifiy `27in`, not `27`

