### PR TITLE
Support dynamically selecting the command and notify characteristics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# IDE
+.idea/

--- a/README.md
+++ b/README.md
@@ -144,15 +144,15 @@ Valid desk commands were discovered by some combination of the following techniq
 
 ## Protocol
 
-The [Uplift Desk Bluetooth adapter](https://www.upliftdesk.com/bluetooth-adapter-for-uplift-desk/) uses a proprietary byte-oriented protocol over the Bluetooth Low Energy (BLE) Generic Attribute Profile (GATT). There are two vendor-defined characteristics: one for sending commands to the Bluetooth adapter (`0xFE61`) and one on which notifications are raised such that clients can receive information from the Bluetooth adapter (`0xFE62`).
+The [Uplift Desk Bluetooth adapter](https://www.upliftdesk.com/bluetooth-adapter-for-uplift-desk/) uses a proprietary byte-oriented protocol over the Bluetooth Low Energy (BLE) Generic Attribute Profile (GATT). There are two vendor-defined characteristics: one for sending commands to the Bluetooth adapter and one on which notifications are raised such that clients can receive information from the Bluetooth adapter.
 
-| GATT Characteristic | Purpose                                                             |
-| ------------------- | ------------------------------------------------------------------- |
-| 0xFE61              | Desk control. Clients write to this to send commands to the server. |
-| 0xFE62              | Desk output. The server sends notifications on this for clients.    |
+| GATT Characteristic | Purpose                                                          |
+|---------------------|------------------------------------------------------------------|
+| 0xFE61 \| 0xFF01    | Desk control. Clients write to this to send commands to the server. |
+| 0xFE62 \| 0xFF02    | Desk output. The server sends notifications on this for clients. |
 
 ### Attribute Value Format
-All attribute values sent to `0xFE61` (commands) and received from `0xFE62` (notifications) follow the same byte-oriented format. Each attribute value consists of two sync bytes (`0xF1F1` for commands, `0xF2F2` for notifications), an opcode byte, a length byte, an optional payload, a checksum byte, and a terminator byte (always `0x7E`).
+All attribute values sent to desk control characteristic (commands) and received from desk output characteristic (notifications) follow the same byte-oriented format. Each attribute value consists of two sync bytes (`0xF1F1` for commands, `0xF2F2` for notifications), an opcode byte, a length byte, an optional payload, a checksum byte, and a terminator byte (always `0x7E`).
 
 #### Attribute Value Format, Commands:
 ```txt

--- a/src/uplift_ble/ble_characteristics.py
+++ b/src/uplift_ble/ble_characteristics.py
@@ -19,8 +19,3 @@ BLE_CHAR_UUID_DIS_FIRMWARE_REV = normalize_uuid_16(0x2A26)
 BLE_CHAR_UUID_DIS_SOFTWARE_REV = normalize_uuid_16(0x2A28)
 BLE_CHAR_UUID_DIS_SYSTEM_ID = normalize_uuid_16(0x2A23)
 BLE_CHAR_UUID_DIS_PNP_ID = normalize_uuid_16(0x2A50)
-
-# UUID for sending control commands to the Uplift BLE adapter.
-BLE_CHAR_UUID_UPLIFT_DESK_CONTROL: str = normalize_uuid_16(0xFE61)
-# UUID for receiving status and output values from the Uplift BLE adapter.
-BLE_CHAR_UUID_UPLIFT_DESK_OUTPUT: str = normalize_uuid_16(0xFE62)

--- a/src/uplift_ble/ble_services.py
+++ b/src/uplift_ble/ble_services.py
@@ -14,4 +14,8 @@ from bleak.uuids import normalize_uuid_16
 # UUID for the BLE Device Information Service (DIS).
 BLE_SERVICE_UUID_DEVICE_INFORMATION_SERVICE: str = normalize_uuid_16(0x180A)
 # UUID for a service which allows clients to discover nearby Uplift adapters.
-BLE_SERVICE_UUID_UPLIFT_DISCOVERY: str = normalize_uuid_16(0xFE60)
+BLE_SERVICE_UUIDS_UPLIFT_DISCOVERY: list[str] = [
+    normalize_uuid_16(0xFE60),
+    normalize_uuid_16(0xff12),
+    normalize_uuid_16(0x00ff),
+]

--- a/src/uplift_ble/scanner.py
+++ b/src/uplift_ble/scanner.py
@@ -1,6 +1,6 @@
 from bleak import BleakScanner
 
-from uplift_ble.ble_services import BLE_SERVICE_UUID_UPLIFT_DISCOVERY
+from uplift_ble.ble_services import BLE_SERVICE_UUIDS_UPLIFT_DISCOVERY
 
 
 class DeskScanner:
@@ -12,7 +12,7 @@ class DeskScanner:
         # Currently this scanner only discovers Uplift desks by service UUID.
         # To support other desk makes/models, refactor to accept a list of service UUIDs or
         # subclass/configure different desk scanners.
-        target_services = [BLE_SERVICE_UUID_UPLIFT_DISCOVERY]
+        target_services = BLE_SERVICE_UUIDS_UPLIFT_DISCOVERY
         devices = await BleakScanner.discover(
             timeout=timeout, service_uuids=target_services
         )


### PR DESCRIPTION
Features:

* Support dynamically finding the command and notify characteristic. Done by looking at the properties for 'write-without-response' and 'notify'
* Expanding the list of service_uuids that have been identified to be Uplift desks and make them discoverable
** https://github.com/Bennett-Wendorf/hass-uplift-desk/issues/5
** https://github.com/Bennett-Wendorf/hass-uplift-desk/issues/4

Referenced https://github.com/justintout/uplift-reconnect and https://github.com/Bennett-Wendorf/hass-uplift-desk for additional information during development