### PR TITLE
feat: document opcode 0x12 and discourage its use

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,39 +156,41 @@ All attribute values sent to `0xFE61` (commands) and received from `0xFE62` (not
 
 ### Known Commands
 
-| Opcode | Length | Attribute Value                           | Purpose                                |
-| ------ | ------ | ----------------------------------------- | -------------------------------------- |
-| 0x01   | 0      | `0xF1,0xF1,0x01,0x00,0x01,0x7E`           | Move desk up                           |
-| 0x02   | 0      | `0xF1,0xF1,0x02,0x00,0x02,0x7E`           | Move desk down                         |
-| 0x05   | 0      | `0xF1,0xF1,0x05,0x00,0x05,0x7E`           | Move to height preset 1                |
-| 0x06   | 0      | `0xF1,0xF1,0x06,0x00,0x06,0x7E`           | Move to height preset 2                |
-| 0x07   | 0      | `0xF1,0xF1,0x07,0x00,0x07,0x7E`           | Request height limits                  |
-| 0x10   | 2      | `0xF1,0xF1,0x10,0x02,0xCA,0xFE,0xDB,0x7E` | Set calibration offset                 |
-| 0x11   | 2      | `0xF1,0xF1,0x11,0x02,0xCA,0xFE,0xDC,0x7E` | Set height limit max                   |
-| 0x1B   | 2      | `0xF1,0xF1,0x1B,0x02,0xCA,0xFE,0xE6,0x7E` | Move to specified height               |
-| 0x21   | 0      | `0xF1,0xF1,0x21,0x00,0x21,0x7E`           | Set current height as height limit max |
-| 0x22   | 0      | `0xF1,0xF1,0x22,0x00,0x22,0x7E`           | Set current height as height limit min |
-| 0x23   | 1      | `0xF1,0xF1,0x23,0x01,0x01,0x25,0x7E`      | Clear height limit max                 |
-| 0x23   | 1      | `0xF1,0xF1,0x23,0x01,0x02,0x26,0x7E`      | Clear height limit min                 |
-| 0x2B   | 0      | `0xF1,0xF1,0x2B,0x00,0x2B,0x7E`           | Stop movement                          |
-| 0x0E   | 1      | `0xF1,0xF1,0x0E,0x01,0x00,0x0F,0x7E`      | Set units to centimeters               |
-| 0x0E   | 1      | `0xF1,0xF1,0x0E,0x01,0x01,0x10,0x7E`      | Set units to inches                    |
-| 0xFE   | 0      | `0xF1,0xF1,0xFE,0x00,0xFE,0x7E`           | Reset                                  |
+| Opcode | Length | Attribute Value                           | Purpose                                                                |
+|--------|--------|-------------------------------------------| -----------------------------------------------------------------------|
+| 0x01   | 0      | `0xF1,0xF1,0x01,0x00,0x01,0x7E`           | Move desk up                                                           |
+| 0x02   | 0      | `0xF1,0xF1,0x02,0x00,0x02,0x7E`           | Move desk down                                                         |
+| 0x05   | 0      | `0xF1,0xF1,0x05,0x00,0x05,0x7E`           | Move to height preset 1                                                |
+| 0x06   | 0      | `0xF1,0xF1,0x06,0x00,0x06,0x7E`           | Move to height preset 2                                                |
+| 0x07   | 0      | `0xF1,0xF1,0x07,0x00,0x07,0x7E`           | Request height limits                                                  |
+| 0x10   | 2      | `0xF1,0xF1,0x10,0x02,0xCA,0xFE,0xDB,0x7E` | Set calibration offset                                                 |
+| 0x11   | 2      | `0xF1,0xF1,0x11,0x02,0xCA,0xFE,0xDC,0x7E` | Set height limit max                                                   |
+| 0x12   | 2      | `0xF1,0xF1,0x12,0x02,0x01,0x00,0x15,0x7E` | Not fully known; potentially dangerous. Sets some configuration value. |
+| 0x1B   | 2      | `0xF1,0xF1,0x1B,0x02,0xCA,0xFE,0xE6,0x7E` | Move to specified height                                               |
+| 0x21   | 0      | `0xF1,0xF1,0x21,0x00,0x21,0x7E`           | Set current height as height limit max                                 |
+| 0x22   | 0      | `0xF1,0xF1,0x22,0x00,0x22,0x7E`           | Set current height as height limit min                                 |
+| 0x23   | 1      | `0xF1,0xF1,0x23,0x01,0x01,0x25,0x7E`      | Clear height limit max                                                 |
+| 0x23   | 1      | `0xF1,0xF1,0x23,0x01,0x02,0x26,0x7E`      | Clear height limit min                                                 |
+| 0x2B   | 0      | `0xF1,0xF1,0x2B,0x00,0x2B,0x7E`           | Stop movement                                                          |
+| 0x0E   | 1      | `0xF1,0xF1,0x0E,0x01,0x00,0x0F,0x7E`      | Set units to centimeters                                               |
+| 0x0E   | 1      | `0xF1,0xF1,0x0E,0x01,0x01,0x10,0x7E`      | Set units to inches                                                    |
+| 0xFE   | 0      | `0xF1,0xF1,0xFE,0x00,0xFE,0x7E`           | Reset                                                                  |
 
 Some of commands above were found by reverse-engineering the Uplift app (v1.1.0) using tools such as JADX. Specifically, the authors read through the .java code for the activities within the `com.jiecang.app.android.aidesk` namespace. Other commands were found by exhaustive search over the range of all opcodes.
 
 ### Known Notifications
 
-| Opcode | Payload Length | Purpose                                                                        | Factory Value (taken from V2-Commercial model) |
-|--------|----------------|--------------------------------------------------------------------------------|------------------------------------------------|
-| 0x01   |       3        | Reports the height of the desk in 0.01 mm (10 µm) increments.                  | Unknown                                        |
-| 0x04   |       0        | Seen when the desk is in an error state and the display shows **ASR**.         | N/A                                            |
-| 0x10   |       2        | Reports the calibration offset in millimeters (2‑byte, big‑endian).            | `572`                                          |
-| 0x11   |       2        | Reports the max height limit in millimeters (2‑byte, big‑endian).              | `671`                                          |
-| 0x25   |       2        | Reports height preset 1. Units vary by hardware/firmware. (2‑byte, big‑endian).| Unknown                                        |
-| 0x26   |       2        | Reports height preset 2. Units vary by hardware/firmware. (2‑byte, big‑endian).| Unknown                                        |
-| 0x27   |       2        | Reports height preset 3. Units vary by hardware/firmware. (2‑byte, big‑endian).| Unknown                                        |
-| 0x28   |       2        | Reports height preset 4. Units vary by hardware/firmware. (2‑byte, big‑endian).| Unknown                                        |
+| Opcode | Payload Length | Purpose                                                                               | Factory Value (taken from V2-Commercial model) |
+|--------|----------------|---------------------------------------------------------------------------------------|------------------------------------------------|
+| 0x01   |       3        | Reports the height of the desk in 0.01 mm (10 µm) increments.                         | Unknown                                        |
+| 0x04   |       0        | Seen when the desk is in an error state and the display shows **ASR**.                | N/A                                            |
+| 0x10   |       2        | Reports the calibration offset in millimeters (2‑byte, big‑endian).                   | `572`                                          |
+| 0x11   |       2        | Reports the max height limit in millimeters (2‑byte, big‑endian).                     | `671`                                          |
+| 0x12   |       2        | Reports some configuration value. The corresponding command is potentially dangerous. | Unknown                                        |
+| 0x25   |       2        | Reports height preset 1. Units vary by hardware/firmware. (2‑byte, big‑endian).       | Unknown                                        |
+| 0x26   |       2        | Reports height preset 2. Units vary by hardware/firmware. (2‑byte, big‑endian).       | Unknown                                        |
+| 0x27   |       2        | Reports height preset 3. Units vary by hardware/firmware. (2‑byte, big‑endian).       | Unknown                                        |
+| 0x28   |       2        | Reports height preset 4. Units vary by hardware/firmware. (2‑byte, big‑endian).       | Unknown                                        |
 
 Most notification packets seem to have opcodes that match the opcode of an associated command packet.
 For example, sending the command packet with opcode=0x01 triggers a notification packet with the same opcode,

--- a/src/uplift_ble/desk.py
+++ b/src/uplift_ble/desk.py
@@ -274,6 +274,17 @@ class Desk:
             logger.info(
                 f"- Received packet, opcode=0x{p.opcode:02X}, height limit max: {mm} mm (~{inches} in)"
             )
+        elif p.opcode == 0x12:
+            # Avoid running the command with the 0x12 opcode!
+            # The 0x12 command takes a 2-byte payload, but setting it to various values causes strange and potentially dangerous behavior.
+            # For example, some payloads make the desk movement jerky, other payloads make the desk move quickly.
+            # If you do change this value, anecdotally, a payload of [0x01, 0x00] restores normal behavior.
+            # It also appears to affect the scaling used for the height display.
+            # Until its behavior is better understood, we recommend avoiding it!
+            raw = p.payload.hex()
+            logger.info(
+                f"- Received packet, opcode=0x{p.opcode:02X}, internal configuration value. Support for this packet type is partial and experimental, payload: 0x{raw}"
+            )
         elif p.opcode == 0x25:
             raw = p.payload.hex()
             logger.info(


### PR DESCRIPTION
This PR does the following:
- Adds logging for `0x12` notifications
- Updates the README with info on the `0x12` opcode

Avoid using opcode `0x12` until its behavior is better understood!

Closes #6