### PR TITLE
feat: add callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Some of commands above were found by reverse-engineering the Uplift app (v1.1.0)
 | Opcode | Payload Length | Purpose                                                                               | Factory Value (taken from V2-Commercial model) |
 |--------|----------------|---------------------------------------------------------------------------------------|------------------------------------------------|
 | 0x01   |       3        | Reports the height of the desk in 0.01 mm (10 µm) increments.                         | Unknown                                        |
-| 0x04   |       0        | Seen when the desk is in an error state and the display shows **ASR**.                | N/A                                            |
+| 0x04   |       0        | Seen when the desk is in an error state and the display shows **RST**.                | N/A                                            |
 | 0x10   |       2        | Reports the calibration offset in millimeters (2‑byte, big‑endian).                   | `572`                                          |
 | 0x11   |       2        | Reports the max height limit in millimeters (2‑byte, big‑endian).                     | `671`                                          |
 | 0x12   |       2        | Reports some configuration value. The corresponding command is potentially dangerous. | Unknown                                        |
@@ -210,8 +210,8 @@ This table summarizes some examples of what the Desk's display shows for various
 | 762                     | inches    | 30.1                                                                 |
 | 2537                    | inches    | 100                                                                  |
 | 25396                   | inches    | 999                                                                  |
-| 25397                   | inches    | *Weird state!* Display shows **ASR** but desk can still move.        |
-| 65535                   | inches    | *Weird state!* Display shows **ASR** but desk can still move.        |
+| 25397                   | inches    | *Weird state!* Display shows **RST** but desk can still move.        |
+| 65535                   | inches    | *Weird state!* Display shows **RST** but desk can still move.        |
 
 
 ## Security of the Uplift BLE Adapter

--- a/src/uplift_ble/units.py
+++ b/src/uplift_ble/units.py
@@ -9,7 +9,7 @@ def convert_mm_to_in(mm: int | float) -> float:
     return round_half_up(mm * 0.039, num_digits=1)
 
 
-def convert_hundredths_of_mm_to_mm(hundredths_of_mm: int | float) -> float:
+def convert_hundredths_mm_to_whole_mm(hundredths_of_mm: int) -> int:
     """
     Converts a value in hundredths of a millimeter to millimeters, rounding using half-up to the nearest whole number.
     """

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,7 +1,7 @@
 import pytest
 from uplift_ble.units import (
     convert_mm_to_in,
-    convert_hundredths_of_mm_to_mm,
+    convert_hundredths_mm_to_whole_mm,
     round_half_up,
 )
 
@@ -24,8 +24,8 @@ def test_convert_mm_to_in(input: float, expected: float):
     "input,expected",
     [(0, 0), (100, 1), (1000, 10), (10000, 100), (40, 0), (50, 1), (60, 1)],
 )
-def test_convert_hundredths_of_mm_to_mm(input: float, expected: float):
-    actual = convert_hundredths_of_mm_to_mm(input)
+def test_convert_hundredths_mm_to_whole_mm(input: float, expected: int):
+    actual = convert_hundredths_mm_to_whole_mm(input)
     assert actual == expected
 
 


### PR DESCRIPTION
This PR does the following:
- Adds `on_notification_height` callback
- Adds `on_notification_rst` callback
- Adds `on_notification_calibration_height` callback
- Adds `on_notification_height_limit_max` callback
- Changes "ASR" to "RST" in README to standardize language
- Standardizes unit precision to integer millimeters

We favor a simple callback approach rather than a full event system. Simple is better than complex. Explicit is better than clever.

Closes #8