### PR TITLE
feat: support ble generic access service, gap

### DIFF
--- a/scripts/uplift_ble_cli.py
+++ b/scripts/uplift_ble_cli.py
@@ -114,7 +114,18 @@ def listen(
 
 
 @app.command()
-def get_device_information(ctx: typer.Context):
+def get_ble_gap_values(ctx: typer.Context):
+    """
+    Get standard BLE generic attribute service (GAP) values.
+    """
+    address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
+    requires_wake = ctx.obj["requires_wake"]
+    device_info = asyncio.run(Desk(address, requires_wake).get_ble_gap_values())
+    typer.echo(json.dumps(device_info, indent=4, ensure_ascii=False))
+
+
+@app.command()
+def get_ble_dis_values(ctx: typer.Context):
     """
     Get standard BLE device information service (DIS) values.
 
@@ -125,7 +136,7 @@ def get_device_information(ctx: typer.Context):
     """
     address = _resolve_address(ctx.obj["address"], ctx.obj["timeout"])
     requires_wake = ctx.obj["requires_wake"]
-    device_info = asyncio.run(Desk(address, requires_wake).get_device_information())
+    device_info = asyncio.run(Desk(address, requires_wake).get_ble_dis_values())
     typer.echo(json.dumps(device_info, indent=4, ensure_ascii=False))
 
 

--- a/src/uplift_ble/ble_characteristics.py
+++ b/src/uplift_ble/ble_characteristics.py
@@ -11,6 +11,11 @@ https://www.bluetooth.com/specifications/assigned-numbers/
 
 from bleak.uuids import normalize_uuid_16
 
+BLE_CHAR_UUID_GAP_DEVICE_NAME = normalize_uuid_16(0x2A00)
+BLE_CHAR_UUID_GAP_APPEARANCE = normalize_uuid_16(0x2A01)
+BLE_CHAR_UUID_GAP_PERIPHERAL_PRIVACY_FLAG = normalize_uuid_16(0x2A02)
+BLE_CHAR_UUID_GAP_PERIPHERAL_PREFERRED_CONNECTION_PARAMETERS = normalize_uuid_16(0x2A04)
+
 BLE_CHAR_UUID_DIS_MANUFACTURER_NAME = normalize_uuid_16(0x2A29)
 BLE_CHAR_UUID_DIS_MODEL_NUMBER = normalize_uuid_16(0x2A24)
 BLE_CHAR_UUID_DIS_SERIAL_NUMBER = normalize_uuid_16(0x2A25)

--- a/src/uplift_ble/ble_services.py
+++ b/src/uplift_ble/ble_services.py
@@ -11,6 +11,8 @@ https://www.bluetooth.com/specifications/assigned-numbers/
 
 from bleak.uuids import normalize_uuid_16
 
+# UUID for the BLE Generic Access Service (GAP).
+BLE_SERVICE_UUID_GENERIC_ACCESS_SERVICE: str = normalize_uuid_16(0x1800)
 # UUID for the BLE Device Information Service (DIS).
 BLE_SERVICE_UUID_DEVICE_INFORMATION_SERVICE: str = normalize_uuid_16(0x180A)
 # UUID for a service which allows clients to discover nearby Uplift adapters.


### PR DESCRIPTION
This PR changes the following:
- Adds support for reading standard generic access service characteristics
- Adds new `get_ble_gap_values` method
- Replaces `get_device_information` method with `get_ble_dis_values`

Closes #10