### PR TITLE
feat: add support for service UUID 0xFF12

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ from uplift_ble.scanner import DeskScanner
 
 async def main():
     # The `DeskScanner` class is used to discover nearby desk adapters and their Bluetooth MAC addresses.
-    addresses = await DeskScanner.discover()
+    devices = await DeskScanner.discover()
 
-    if len(addresses) == 0:
+    if len(devices) == 0:
         print("Error: no desks found.", file=sys.stderr)
         sys.exit(1)
-    elif len(addresses) > 1:
+    elif len(devices) > 1:
         print("Error: multiple desks found. Exiting for safety.", file=sys.stderr)
         sys.exit(1)
 
     # The `Desk` class represents a desk and supports the async context manager API.
-    async with Desk(address=addresses[0]) as desk:
+    async with Desk(address=devices[0].address) as desk:
         height_before_move = await desk.get_current_height()
         await desk.move_up()
         height_after_move = await desk.get_current_height()

--- a/src/uplift_ble/ble_services.py
+++ b/src/uplift_ble/ble_services.py
@@ -15,5 +15,7 @@ from bleak.uuids import normalize_uuid_16
 BLE_SERVICE_UUID_GENERIC_ACCESS_SERVICE: str = normalize_uuid_16(0x1800)
 # UUID for the BLE Device Information Service (DIS).
 BLE_SERVICE_UUID_DEVICE_INFORMATION_SERVICE: str = normalize_uuid_16(0x180A)
-# UUID for a service which allows clients to discover nearby Uplift adapters.
-BLE_SERVICE_UUID_UPLIFT_DISCOVERY: str = normalize_uuid_16(0xFE60)
+# UUID for vendor-specific discovery service. Based on reverse-engineered Uplift app code.
+BLE_SERVICE_UUID_UPLIFT_DISCOVERY_LIERDA_V1: str = normalize_uuid_16(0xFF12)
+# UUID for vendor-specific discovery service. Based on reverse-engineered Uplift app code.
+BLE_SERVICE_UUID_UPLIFT_DISCOVERY_LIERDA_V2: str = normalize_uuid_16(0xFE60)

--- a/src/uplift_ble/scanner.py
+++ b/src/uplift_ble/scanner.py
@@ -1,20 +1,59 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Optional
+
 from bleak import BleakScanner
 
-from uplift_ble.ble_services import BLE_SERVICE_UUID_UPLIFT_DISCOVERY
+from uplift_ble.ble_services import (
+    BLE_SERVICE_UUID_UPLIFT_DISCOVERY_LIERDA_V1,
+    BLE_SERVICE_UUID_UPLIFT_DISCOVERY_LIERDA_V2,
+)
+
+
+@dataclass
+class DiscoveredDesk:
+    """
+    Represents a device found during device discovery that appears to be an Uplift desk.
+    """
+
+    address: str
+    """BLE MAC address of the device (e.g., 'F1:45:F1:XX:XX:XX')."""
+    advertised_service_uuids: list[str]
+    """List of service UUIDs advertised in BLE advertisement packets."""
+    name: Optional[str] = None
+    """Human-readable device name from BLE advertisement, if available."""
 
 
 class DeskScanner:
     @staticmethod
-    async def discover(timeout: float = 5.0) -> list[str]:
+    async def discover(timeout: float = 5.0) -> list[DiscoveredDesk]:
         """
-        Returns a list of BLE addresses for any discovered desks.
+        Returns a list of discovered devices that look like standing desks.
         """
-        # Currently this scanner only discovers Uplift desks by service UUID.
-        # To support other desk makes/models, refactor to accept a list of service UUIDs or
-        # subclass/configure different desk scanners.
-        target_services = [BLE_SERVICE_UUID_UPLIFT_DISCOVERY]
-        devices = await BleakScanner.discover(
-            timeout=timeout, service_uuids=target_services
+        target_services = [
+            BLE_SERVICE_UUID_UPLIFT_DISCOVERY_LIERDA_V1,
+            BLE_SERVICE_UUID_UPLIFT_DISCOVERY_LIERDA_V2,
+        ]
+
+        # Use BleakScanner with a detection callback to access advertisement data.
+        discovered = {}
+
+        def detection_callback(device, advertisement_data):
+            if device.address not in discovered:
+                all_advertised_service_uuids = advertisement_data.service_uuids or []
+
+                discovered[device.address] = DiscoveredDesk(
+                    address=device.address,
+                    advertised_service_uuids=all_advertised_service_uuids,
+                    name=device.name,
+                )
+
+        scanner = BleakScanner(
+            detection_callback=detection_callback, service_uuids=target_services
         )
 
-        return [d.address for d in devices]
+        await scanner.start()
+        await asyncio.sleep(timeout)
+        await scanner.stop()
+
+        return list(discovered.values())


### PR DESCRIPTION
This PR changes the following:
- Adds experimental support for service UUID `0xFF12`
- Overhauls `DeskScanner` to return additional information per device
- Adds advertised service UUIDs to the logs for device discovery
- Updates the README to reflect the new discovery API

We call `0xFF12` BLE_SERVICE_UUID_UPLIFT_DISCOVERY_LIERDA_V1. We call `0xFE60` BLE_SERVICE_UUID_UPLIFT_DISCOVERY_LIERDA_V2.

These version numbers are guesses based on the reverse-engineered app code. The manufacturer name, Lierda, was discovered in variable names.

Further, ther is an existing repo,
[flutter-reconnect](https://github.com/justintout/uplift-reconnect), that uses the service UUID `0xFF12`, and was last authored 5 years ago. This supports the hypothesis that `0xFF12` predates `0xFE60`.

Additionally, the code in
[flutter-reconnect](https://github.com/justintout/uplift-reconnect), along with the reverse-engineered source code from the Uplift app, strongly suggests that the payloads used by the `move_up` and `move_down` methods are identical regardless of whether the service UUID is `0xFF12` or `0xFE60`. However, full parity between desks using these two different service UUID has not been verified.

Use caution if your desk advertises a service UUID of `0xFF12` until more real-world testing can be done!

Closes #12
Related to #2