### PR TITLE
fix: make typer optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ These instructions are intended for Linux users but are likely broadly applicabl
 2. **Create & Activate Virtual Environment**
     ```bash
     python3 -m venv venv
-    source venv/bin/activate
+    source venv/bin/activate # On Windows: venv\Scripts\activate
     ```
 3. **Verify Virtual Environment**
     ```bash
@@ -102,11 +102,10 @@ These instructions are intended for Linux users but are likely broadly applicabl
     ```
 4. **Install Dependencies**
     ```bash
-    python3 -m pip install .
+    python3 -m pip install -e '.[cli,test]'
     ```
-5. **Install Test Dependencies and Run Tests (Optional)**
+5. **Run Tests (Optional)**
     ```bash
-    python3 -m pip install -e ".[test]"
     python3 -m pytest -v
     ```
 6. **Run the CLI**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ authors = [
 ]
 dependencies = [
   "bleak>=1.0.1",
-  "typer>=0.16.0",
 ]
 
 description = "Python library for controlling Uplift standing desks over Bluetooth Low Energy via the official Uplift BLE adapter"
@@ -32,6 +31,9 @@ Homepage = "https://github.com/librick/uplift_ble"
 Issues   = "https://github.com/librick/uplift_ble/issues"
 
 [project.optional-dependencies]
+cli = [
+  "typer>=0.16.0",
+]
 test = [
   "pytest>=8.4.1",
 ]

--- a/scripts/uplift_ble_cli.py
+++ b/scripts/uplift_ble_cli.py
@@ -6,13 +6,19 @@ CLI to test the uplift_ble module.
 import asyncio
 import json
 import logging
-
-import click
-import typer
 from typing import List, Optional
 
-from param_type_height import HEIGHT
-from param_type_mac_address import MAC_ADDRESS
+try:
+    import typer
+    import click
+    from param_type_height import HEIGHT
+    from param_type_mac_address import MAC_ADDRESS
+except ImportError:
+    raise ImportError(
+        "Typer is required for CLI functionality. "
+        "Install with: pip install 'uplift-ble[cli]'"
+    )
+
 from uplift_ble import units
 from uplift_ble.desk import Desk
 from uplift_ble.scanner import DeskScanner, DiscoveredDesk


### PR DESCRIPTION
This PR changes the following:
- Makes typer an optional (cli) dependency
- Adds try/catch to CLI to provide helpful hint on import
- Revises installation notes in README
- Adds Windows-compatible instructions in README

Closes #25