### PR TITLE
Create bleak client with address for compatability

### DIFF
--- a/src/uplift_ble/desk_validator.py
+++ b/src/uplift_ble/desk_validator.py
@@ -136,7 +136,7 @@ class DeskValidator:
 def _create_default_client(
     device: BLEDeviceProtocol, timeout: float
 ) -> BLEClientProtocol:
-    return BleakClient(address_or_ble_device=device, timeout=timeout)
+    return BleakClient(address_or_ble_device=device.address, timeout=timeout)
 
 
 def _service_has_required_characteristics(


### PR DESCRIPTION
The `BleakClient` constructor requires exactly either a string address or a `BLEDevice` object. Your `BLEDeviceProtocol` that's passed as a parameter to `_create_default_client` _can_ match these requirements, but your protocol doesn't actually specify that it does. This works by chance in your cli tool because the instance of your `BLEDeviceProtocol` that you pass to that method is actually a `BLEDevice`. 

Unfortunately for the use-case of my HA integration, I don't always have a `BLEDevice` since those can only really be obtained through a Bleak scanner or something similar. In the integration, once a desk is configured, I don't want to have to scan for it every time HA restarts or the connection is lost. Because of that, the integration configuration only stores the desk name and address. Using that information, I _can_ create an object that satisfies your `BLEDeviceProtocol` but is not actually a `BLEDevice`.

With all that being said, the `BleakClient` constructor that takes a `BLEDevice` is actually just a wrapper for the one that takes an address anyway, so this change tweaks your call to that constructor to just use the address directly instead, thus making it fully and truly compatible with any object that satisfies your `BLEDeviceProtocol`.