### PR TITLE
fix: correct height parsing and add save-preset/request-units commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ All attribute values sent to `0xFE61` (commands) and received from `0xFE62` (not
 | ------ | ------ | ----------------------------------------- | ---------------------------------------------------------------------- |
 | 0x01   | 0      | `0xF1,0xF1,0x01,0x00,0x01,0x7E`           | Move desk up                                                           |
 | 0x02   | 0      | `0xF1,0xF1,0x02,0x00,0x02,0x7E`           | Move desk down                                                         |
+| 0x03   | 0      | `0xF1,0xF1,0x03,0x00,0x03,0x7E`           | Save current height as height preset 1                                 |
+| 0x04   | 0      | `0xF1,0xF1,0x04,0x00,0x04,0x7E`           | Save current height as height preset 2                                 |
 | 0x05   | 0      | `0xF1,0xF1,0x05,0x00,0x05,0x7E`           | Move to height preset 1                                                |
 | 0x06   | 0      | `0xF1,0xF1,0x06,0x00,0x06,0x7E`           | Move to height preset 2                                                |
 | 0x07   | 0      | `0xF1,0xF1,0x07,0x00,0x07,0x7E`           | Request height limits                                                  |
@@ -133,6 +135,7 @@ All attribute values sent to `0xFE61` (commands) and received from `0xFE62` (not
 | 0x23   | 1      | `0xF1,0xF1,0x23,0x01,0x01,0x25,0x7E`      | Clear height limit max                                                 |
 | 0x23   | 1      | `0xF1,0xF1,0x23,0x01,0x02,0x26,0x7E`      | Clear height limit min                                                 |
 | 0x2B   | 0      | `0xF1,0xF1,0x2B,0x00,0x2B,0x7E`           | Stop movement                                                          |
+| 0x0E   | 0      | `0xF1,0xF1,0x0E,0x00,0x0E,0x7E`           | Query current display units (response via 0x0E notification)           |
 | 0x0E   | 1      | `0xF1,0xF1,0x0E,0x01,0x00,0x0F,0x7E`      | Set units to centimeters                                               |
 | 0x0E   | 1      | `0xF1,0xF1,0x0E,0x01,0x01,0x10,0x7E`      | Set units to inches                                                    |
 | 0xFE   | 0      | `0xF1,0xF1,0xFE,0x00,0xFE,0x7E`           | Reset                                                                  |
@@ -143,7 +146,7 @@ Some of commands above were found by reverse-engineering the Uplift app (v1.1.0)
 
 | Opcode | Payload Length | Purpose                                                                                                          | Factory Value (taken from V2-Commercial model) |
 | ------ | -------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| 0x01   | 3              | Reports the height of the desk in 0.1 mm (100 µm) increments. Byte 0: unknown (usually 0x00), Bytes 1-2: height. | Unknown                                        |
+| 0x01   | 3              | Reports the desk height in tenths of the configured display unit (inches or cm per 0x0E setting). Bytes 0-1: height (big-endian), Byte 2: unknown. | Unknown                                        |
 | 0x02   | 1              | Reports desk error conditions via single-byte error codes.                                                       | N/A                                            |
 | 0x04   | 0              | Seen when the desk is in an error state and the display shows **RST**.                                           | N/A                                            |
 | 0x07   | 4              | Reports height limit configuration. Bytes 0-1: max height (mm), Bytes 2-3: min height (mm).                      | Unknown                                        |

--- a/src/uplift_ble/desk_controller.py
+++ b/src/uplift_ble/desk_controller.py
@@ -27,7 +27,7 @@ from uplift_ble.packet import (
     create_command_packet,
     parse_notification_packets,
 )
-from uplift_ble.utils import bytes_to_uint16_be, convert_tenths_mm_to_mm
+from uplift_ble.utils import bytes_to_uint16_be, convert_cm_to_mm, convert_in_to_mm
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +103,8 @@ class DeskController:
         self._notify_started = False
 
         # Read-only state, populated by notifications received from the device
-        self._height_mm: float | None = None
+        self._height_raw: int | None = None
+        self._height_raw_unit: DeskUnit | None = None
         self._unit: DeskUnit | None = None
         self._touch_mode: DeskTouchMode | None = None
         self._lock_status: DeskLockStatus | None = None
@@ -125,8 +126,27 @@ class DeskController:
 
     @property
     def height_mm(self) -> float | None:
-        """Current desk height in millimeters (read-only)."""
-        return self._height_mm
+        """Current desk height in millimeters, converted from display units (read-only).
+
+        Returns None if height or display unit has not been received yet.
+        """
+        if self._height_raw is None or self._height_raw_unit is None:
+            return None
+        tenths = self._height_raw
+        if self._height_raw_unit == DeskUnit.INCHES:
+            return convert_in_to_mm(tenths / 10.0)
+        return convert_cm_to_mm(tenths / 10.0)
+
+    @property
+    def height_raw(self) -> int | None:
+        """Current desk height as a raw integer in tenths of display units (read-only).
+
+        The value is tenths of inches or tenths of centimeters depending on the
+        desk's display unit at the time the height was captured. This may differ
+        from the current ``unit`` if the display unit was changed after the last
+        height notification.
+        """
+        return self._height_raw
 
     @property
     def unit(self) -> DeskUnit | None:
@@ -269,23 +289,25 @@ class DeskController:
                 logger.error(f"Error in event handler for {event_type}: {e}")
 
     def _process_notification_0x01(self, payload: bytes) -> None:
-        """
-        Handle notification with opcode 0x01 (current height).
+        """Handle notification with opcode 0x01 (current height).
 
         The payload contains the current desk height as a 3-byte value:
-        - Byte 0: Status/flag byte (anecdotally, always 0x00)
-        - Bytes 1-2: Height as 16-bit big-endian integer in tenths of millimeters
+        - Bytes 0-1: Height as 16-bit big-endian integer in tenths of display units
+        - Byte 2: Unknown (varies across firmware versions)
 
-        Height values are always in tenths of millimeters regardless of unit settings.
+        The height value is in tenths of the desk's configured display unit:
+        tenths of inches when set to inches, tenths of centimeters when set to
+        centimeters.  The display unit can be queried with ``request_units``.
         """
         expected_len = 3
         if len(payload) != expected_len:
             self._log_payload_length_warning(0x01, payload, expected_len)
             return
-        # Skip status byte at position 0, extract height from bytes 1-2
-        height_tenths_of_mm = bytes_to_uint16_be(payload[1:3])
-        self._height_mm = convert_tenths_mm_to_mm(height_tenths_of_mm)
-        self._emit(DeskEventType.HEIGHT, self._height_mm)
+        self._height_raw = bytes_to_uint16_be(payload[0:2])
+        self._height_raw_unit = self._unit
+        height_mm = self.height_mm
+        if height_mm is not None:
+            self._emit(DeskEventType.HEIGHT, height_mm)
 
     def _process_notification_0x02(self, payload: bytes) -> None:
         """
@@ -346,17 +368,15 @@ class DeskController:
         )
 
     def _process_notification_0x0E(self, payload: bytes) -> None:
-        """
-        Handle notification with opcode 0x0E (display unit preference).
+        """Handle notification with opcode 0x0E (display unit preference).
 
         The payload contains a 1-byte value indicating the unit system for display:
         - 0x00: Centimeters
         - 0x01: Inches
 
-        This setting primarily affects how the desk's attached display (if any) shows heights
-        and what unit preference the app should use. The desk firmware always reports
-        actual height values in fixed units (tenths of mm for current height, mm for limits)
-        regardless of this setting.
+        The desk reports height values (opcode 0x01) in tenths of the configured
+        display unit, so this setting is required to correctly interpret heights.
+        Send opcode 0x0E with an empty payload to query the current setting.
         """
         expected_len = 1
         if len(payload) != expected_len:
@@ -368,6 +388,11 @@ class DeskController:
             return
         self._unit = unit
         self._emit(DeskEventType.UNIT, self._unit)
+        if self._height_raw is not None and self._height_raw_unit is None:
+            self._height_raw_unit = unit
+            height_mm = self.height_mm
+            if height_mm is not None:
+                self._emit(DeskEventType.HEIGHT, height_mm)
 
     def _process_notification_0x19(self, payload: bytes) -> None:
         """
@@ -550,11 +575,23 @@ class DeskController:
 
     @command_writer()
     def move_to_height_preset_1(self) -> DeskCommand:
+        """Recall height preset 1 (move the desk to the stored position)."""
         return DeskCommand(opcode=0x05, payload=b"")
 
     @command_writer()
     def move_to_height_preset_2(self) -> DeskCommand:
+        """Recall height preset 2 (move the desk to the stored position)."""
         return DeskCommand(opcode=0x06, payload=b"")
+
+    @command_writer()
+    def save_height_preset_1(self) -> DeskCommand:
+        """Save the current desk height as height preset 1."""
+        return DeskCommand(opcode=0x03, payload=b"")
+
+    @command_writer()
+    def save_height_preset_2(self) -> DeskCommand:
+        """Save the current desk height as height preset 2."""
+        return DeskCommand(opcode=0x04, payload=b"")
 
     @command_writer()
     def request_height_limits(self) -> DeskCommand:
@@ -608,6 +645,14 @@ class DeskController:
     @command_writer()
     def stop_movement(self) -> DeskCommand:
         return DeskCommand(opcode=0x2B, payload=b"")
+
+    @command_writer()
+    def request_units(self) -> DeskCommand:
+        """Query the desk's configured display unit (inches or centimeters).
+
+        The desk responds with a 0x0E notification containing the current setting.
+        """
+        return DeskCommand(opcode=0x0E, payload=b"")
 
     @command_writer()
     def set_units(self, unit: DeskUnit) -> DeskCommand:


### PR DESCRIPTION
## Summary

Fixes the height notification (0x01) parsing bug reported in #42, and adds missing commands for preset saving and unit querying.

## Height parsing fix

Two bugs in `_process_notification_0x01`:

1. **Wrong byte slice**: was reading `payload[1:3]`, should be `payload[0:2]`
2. **Wrong unit assumption**: was treating the value as tenths of millimeters, but the desk actually reports tenths of the **configured display unit** (inches or centimeters)

The display unit is set via the physical keypad and affects how the desk reports heights over BLE. The `height_mm` property now converts from display units to millimeters using the `unit` property.

## Unit querying

Sending opcode 0x0E with an **empty payload** queries the current display unit setting. The desk responds with a 0x0E notification: `0x00` = centimeters, `0x01` = inches. This was discovered empirically on a 0xFF00 variant (`L-BTMEB95-07014-03`, firmware `v1.01.Jul 25 2023`) and confirmed by toggling the setting on the physical keypad.

New command: `request_units()`

## Save preset commands

The Uplift mobile app stores presets on the phone, not on the BLE adapter. Desks that have only been configured via the app will have empty preset slots on the adapter, causing `move_to_height_preset_1()` / `move_to_height_preset_2()` to silently do nothing.

New commands:
- `save_height_preset_1()` (opcode 0x03)
- `save_height_preset_2()` (opcode 0x04)

These write the current desk height to the adapter's preset slots, after which the recall commands work correctly.

## New property

- `height_raw`: exposes the raw integer value in tenths of display units, useful for consumers that want to avoid the mm conversion

## Testing

Verified on a Jiecang 0xFF00 variant (`L-BTMEB95-07014-03`, firmware `v1.01.Jul 25 2023`, display unit: inches):
- Height readings now match the keypad display (±0.1 inch)
- `request_units()` correctly returns inches (0x01) and centimeters (0x00) after toggling via the keypad
- `save_height_preset_1()` / `save_height_preset_2()` successfully write presets to the adapter, after which recall commands move the desk

Closes #42