### PR TITLE
feat: add cli commands for save height preset and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The compatibility table below provides rough guidance based on unofficial feedba
 | wake                                   | ⚠️              | ✅              | ⚠️              | ⚠️              | ⚠️    | ⚠️       | ⚠️   | ⚠️     | ⚠️       |
 | move_up                                | ⚠️              | ✅              | ⚠️              | ⚠️              | ⚠️    | ⚠️       | ⚠️   | ⚠️     | ⚠️       |
 | move_down                              | ⚠️              | ✅              | ⚠️              | ⚠️              | ⚠️    | ⚠️       | ⚠️   | ⚠️     | ⚠️       |
+| save_height_preset_1                   | ⚠️              | ✅              | ✅              | ⚠️              | ⚠️    | ⚠️       | ⚠️   | ⚠️     | ⚠️       |
+| save_height_preset_2                   | ⚠️              | ✅              | ✅              | ⚠️              | ⚠️    | ⚠️       | ⚠️   | ⚠️     | ⚠️       |
 | move_to_height_preset_1                | ⚠️              | ✅              | ⚠️              | ⚠️              | ⚠️    | ⚠️       | ⚠️   | ⚠️     | ⚠️       |
 | move_to_height_preset_2                | ⚠️              | ✅              | ⚠️              | ⚠️              | ⚠️    | ⚠️       | ⚠️   | ⚠️     | ⚠️       |
 | request_height_limits                  | ⚠️              | ⚠️              | ⚠️              | ⚠️              | ⚠️    | ⚠️       | ⚠️   | ⚠️     | ⚠️       |

--- a/src/uplift_ble/desk_controller.py
+++ b/src/uplift_ble/desk_controller.py
@@ -574,16 +574,6 @@ class DeskController:
         return DeskCommand(opcode=0x02, payload=b"")
 
     @command_writer()
-    def move_to_height_preset_1(self) -> DeskCommand:
-        """Recall height preset 1 (move the desk to the stored position)."""
-        return DeskCommand(opcode=0x05, payload=b"")
-
-    @command_writer()
-    def move_to_height_preset_2(self) -> DeskCommand:
-        """Recall height preset 2 (move the desk to the stored position)."""
-        return DeskCommand(opcode=0x06, payload=b"")
-
-    @command_writer()
     def save_height_preset_1(self) -> DeskCommand:
         """Save the current desk height as height preset 1."""
         return DeskCommand(opcode=0x03, payload=b"")
@@ -592,6 +582,16 @@ class DeskController:
     def save_height_preset_2(self) -> DeskCommand:
         """Save the current desk height as height preset 2."""
         return DeskCommand(opcode=0x04, payload=b"")
+
+    @command_writer()
+    def move_to_height_preset_1(self) -> DeskCommand:
+        """Recall height preset 1 (move the desk to the stored position)."""
+        return DeskCommand(opcode=0x05, payload=b"")
+
+    @command_writer()
+    def move_to_height_preset_2(self) -> DeskCommand:
+        """Recall height preset 2 (move the desk to the stored position)."""
+        return DeskCommand(opcode=0x06, payload=b"")
 
     @command_writer()
     def request_height_limits(self) -> DeskCommand:

--- a/src/uplift_ble_cli/cli.py
+++ b/src/uplift_ble_cli/cli.py
@@ -198,6 +198,26 @@ async def move_down(controller: DeskController):
 
 @cli.command()
 @with_desk_controller
+async def save_height_preset_1(controller: DeskController):
+    """Save the current desk height as height preset 1."""
+    await controller.save_height_preset_1()
+    click.echo(
+        "Sent command to save desk's current height as height preset 1", err=True
+    )
+
+
+@cli.command()
+@with_desk_controller
+async def save_height_preset_2(controller: DeskController):
+    """Save the current desk height as height preset 2."""
+    await controller.save_height_preset_2()
+    click.echo(
+        "Sent command to save desk's current height as height preset 2", err=True
+    )
+
+
+@cli.command()
+@with_desk_controller
 async def move_to_height_preset_1(controller: DeskController):
     """Move the desk to programmed height preset 1."""
     await controller.move_to_height_preset_1()


### PR DESCRIPTION
This PR changes the following:
- Adds save height preset 1 as a CLI command
- Adds save height preset 2 as a CLI command
- Rearranges `DeskController` command_writers to follow opcode order
- Updates compatibility table in README

The save height preset 1 & 2 commands have been verified to work for variant `0xFF00`.

See #46

As part of this commit, I've verified that this pair of commands also works for variant `0xFE60`.